### PR TITLE
Removed ext-gmp as hard dependency

### DIFF
--- a/Analyzer/ES256KeyAnalyzer.php
+++ b/Analyzer/ES256KeyAnalyzer.php
@@ -21,6 +21,10 @@ final class ES256KeyAnalyzer implements KeyAnalyzer
 {
     public function analyze(JWK $jwk, MessageBag $bag): void
     {
+        if (! \extension_loaded('gmp')) {
+            throw new \LogicException(static::class . ' requires gmp extension');
+        }
+
         if ('EC' !== $jwk->get('kty')) {
             return;
         }

--- a/Analyzer/ES384KeyAnalyzer.php
+++ b/Analyzer/ES384KeyAnalyzer.php
@@ -21,6 +21,10 @@ final class ES384KeyAnalyzer implements KeyAnalyzer
 {
     public function analyze(JWK $jwk, MessageBag $bag): void
     {
+        if (! \extension_loaded('gmp')) {
+            throw new \LogicException(static::class . ' requires gmp extension');
+        }
+
         if ('EC' !== $jwk->get('kty')) {
             return;
         }

--- a/Analyzer/ES512KeyAnalyzer.php
+++ b/Analyzer/ES512KeyAnalyzer.php
@@ -21,6 +21,10 @@ final class ES512KeyAnalyzer implements KeyAnalyzer
 {
     public function analyze(JWK $jwk, MessageBag $bag): void
     {
+        if (! \extension_loaded('gmp')) {
+            throw new \LogicException(static::class . ' requires gmp extension');
+        }
+
         if ('EC' !== $jwk->get('kty')) {
             return;
         }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
     },
     "require": {
         "ext-openssl": "*",
-        "ext-gmp": "*",
         "psr/http-factory": "^1.0",
         "psr/http-client": "^1.0",
         "web-token/jwt-core": "^2.0",


### PR DESCRIPTION
`ext-gmp` is only used on some key analyzer. It's not necessary to have the `gmp` extension installed for a standard use.